### PR TITLE
Change inline configuration format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 env: {}
 
-# FILE GENERATED WITH: npx ghat
+# FILE GENERATED WITH: npx ghat fregante/ghatemplates/node
 # SOURCE: https://github.com/fregante/ghatemplates
-# OPTIONS: {"source":"fregante/ghatemplates/node","exclude":["jobs.Test"]}
+# OPTIONS: {"exclude":["jobs.Test"]}
 
 name: CI
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,8 @@
-env:
-  ghat:
-    source: https://github.com/fregante/ghatemplates/node
-    exclude:
-      - jobs.Test
+env: {}
 
-# UPDATE FILE BY RUNNING: npx ghat
+# FILE GENERATED WITH: npx ghat
+# SOURCE: https://github.com/fregante/ghatemplates
+# OPTIONS: {"source":"fregante/ghatemplates/node","exclude":["jobs.Test"]}
 
 name: CI
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
-env: {}
+env:
+  ghat:
+    source: https://github.com/fregante/ghatemplates/node
+    exclude:
+      - jobs.Test
 
-# DO NOT EDIT BELOW - use `npx ghat fregante/ghatemplates/node --exclude jobs.Test`
+# UPDATE FILE BY RUNNING: npx ghat
 
 name: CI
 on:
@@ -22,4 +26,4 @@ jobs:
       - name: install
         run: npm ci || npm install
       - name: build
-        run: npm run build --if-present
+        run: npm run build

--- a/bin.js
+++ b/bin.js
@@ -28,7 +28,6 @@ prog
 	.action(async (source, options) => {
 		normalizeFlagArray(options, 'exclude');
 		normalizeFlagArray(options, 'set');
-		options.argv = process.argv;
 
 		try {
 			await ghat(source, options);

--- a/lib.js
+++ b/lib.js
@@ -114,11 +114,20 @@ async function ghat(source, {exclude, set}) {
 			remote.string = yaml.dump(remote.parsed, {noCompatMode: true});
 		}
 
+		const comments = [
+			`FILE GENERATED WITH: npx ghat ${source}`,
+			`SOURCE: ${getRepoUrl(source).url}`
+		];
+
+		if (exclude || set) {
+			comments.push(
+				`OPTIONS: ${JSON.stringify({exclude, set})}`
+			);
+		}
+
 		await fs.writeFile(localWorkflowPath, outdent`
 			${yaml.dump({env})}
-			# FILE GENERATED WITH: npx ghat
-			# SOURCE: ${getRepoUrl(source).url}
-			# OPTIONS: ${JSON.stringify({source, exclude, set})}
+			${comments.map(line => '# ' + line).join('\n')}
 
 			${await remote.string}`
 		);

--- a/lib.js
+++ b/lib.js
@@ -6,8 +6,9 @@ const yaml = require('js-yaml');
 const degit = require('degitto');
 const dotProp = require('dot-prop');
 const {outdent} = require('outdent');
-const shellEscape = require('shell-escape');
 const splitOnFirst = require('split-on-first');
+
+const getRepoUrl = require('./parse-repo.js');
 
 class InputError extends Error {}
 
@@ -45,7 +46,7 @@ async function getWorkflows(directory) {
 	return findYamlFiles(directory, '.github/workflows');
 }
 
-async function ghat(source, {exclude, set, argv}) {
+async function ghat(source, {exclude, set}) {
 	if (!source) {
 		throw new InputError('No source was specified');
 	}
@@ -94,6 +95,8 @@ async function ghat(source, {exclude, set, argv}) {
 			}
 
 			needsUpdate = true;
+		} else {
+			exclude = undefined;
 		}
 
 		if (set.length > 0) {
@@ -103,15 +106,19 @@ async function ghat(source, {exclude, set, argv}) {
 			}
 
 			needsUpdate = true;
+		} else {
+			set = undefined;
 		}
 
 		if (needsUpdate) {
 			remote.string = yaml.dump(remote.parsed, {noCompatMode: true});
 		}
 
+		const {url, subdir} = getRepoUrl(source);
+		env.ghat = {source: url + subdir, exclude, set};
 		await fs.writeFile(localWorkflowPath, outdent`
 			${yaml.dump({env})}
-			# DO NOT EDIT BELOW, USE: npx ghat ${shellEscape(argv.slice(2))}
+			# FILE GENERATED WITH: npx ghat
 
 			${await remote.string}`
 		);

--- a/lib.js
+++ b/lib.js
@@ -114,11 +114,11 @@ async function ghat(source, {exclude, set}) {
 			remote.string = yaml.dump(remote.parsed, {noCompatMode: true});
 		}
 
-		const {url, subdir} = getRepoUrl(source);
-		env.ghat = {source: url + subdir, exclude, set};
 		await fs.writeFile(localWorkflowPath, outdent`
 			${yaml.dump({env})}
 			# FILE GENERATED WITH: npx ghat
+			# SOURCE: ${getRepoUrl(source).url}
+			# OPTIONS: ${JSON.stringify({source, exclude, set})}
 
 			${await remote.string}`
 		);

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
 				"js-yaml": "^4.0.0",
 				"outdent": "^0.8.0",
 				"sade": "^1.7.4",
-				"shell-escape": "^0.2.0",
 				"split-on-first": "^2.0.1",
 				"xo": "^0.37.1"
 			}
@@ -7113,12 +7112,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/shell-escape": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/shell-escape/-/shell-escape-0.2.0.tgz",
-			"integrity": "sha1-aP0CXrBJC09WegJ/C/IkgLX4QTM=",
-			"dev": true
-		},
 		"node_modules/signal-exit": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -14161,12 +14154,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-			"dev": true
-		},
-		"shell-escape": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/shell-escape/-/shell-escape-0.2.0.tgz",
-			"integrity": "sha1-aP0CXrBJC09WegJ/C/IkgLX4QTM=",
 			"dev": true
 		},
 		"signal-exit": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
 		"prepack": "npm run build",
 		"test": "npm run build && xo"
 	},
-	"dependencies": {},
 	"devDependencies": {
 		"@vercel/ncc": "^0.27.0",
 		"degitto": "^2.8.2",
@@ -38,7 +37,6 @@
 		"js-yaml": "^4.0.0",
 		"outdent": "^0.8.0",
 		"sade": "^1.7.4",
-		"shell-escape": "^0.2.0",
 		"split-on-first": "^2.0.1",
 		"xo": "^0.37.1"
 	}

--- a/parse-repo.js
+++ b/parse-repo.js
@@ -1,0 +1,41 @@
+// Extracted from degit
+const supported = new Set(['github', 'gitlab', 'bitbucket', 'git.sr.ht']);
+
+module.exports = function parse(src) {
+	const match = /^(?:(?:https:\/\/)?([^:/]+\.[^:/]+)\/|git@([^:/]+)[:/]|([^/]+):)?([^/\s]+)\/([^/\s#]+)(?:((?:\/[^/\s#]+)+))?(?:\/)?(?:#(.+))?/.exec(
+		src
+	);
+	if (!match) {
+		throw new DegitError(`could not parse ${src}`, {
+			code: 'BAD_SRC'
+		});
+	}
+
+	const site = (match[1] || match[2] || match[3] || 'github').replace(
+		/\.(com|org)$/,
+		''
+	);
+	if (!supported.has(site)) {
+		throw new DegitError(
+			`degit supports GitHub, GitLab, Sourcehut and BitBucket`,
+			{
+				code: 'UNSUPPORTED_HOST'
+			}
+		);
+	}
+
+	const user = match[4];
+	const name = match[5].replace(/\.git$/, '');
+	const subdir = match[6];
+	const ref = match[7] || 'HEAD';
+
+	const domain = `${site}.${
+		site === 'bitbucket' ? 'org' : site === 'git.sr.ht' ? '' : 'com'
+	}`;
+	const url = `https://${domain}/${user}/${name}`;
+	const ssh = `git@${domain}:${user}/${name}`;
+
+	const mode = supported.has(site) ? 'tar' : 'git';
+
+	return { site, user, name, ref, url, ssh, subdir, mode };
+}

--- a/parse-repo.js
+++ b/parse-repo.js
@@ -9,7 +9,7 @@ class DegitError extends Error {
 	}
 }
 
-module.exports = function parse(src) {
+module.exports = src => {
 	const match = /^(?:(?:https:\/\/)?([^:/]+\.[^:/]+)\/|git@([^:/]+)[:/]|([^/]+):)?([^/\s]+)\/([^/\s#]+)(?:((?:\/[^/\s#]+)+))?\/?(?:#(.+))?/.exec(
 		src
 	);

--- a/parse-repo.js
+++ b/parse-repo.js
@@ -1,5 +1,13 @@
 // Extracted from degit
+// TODO: Export from degitto instead
 const supported = new Set(['github', 'gitlab', 'bitbucket', 'git.sr.ht']);
+
+class DegitError extends Error {
+	constructor(message, options) {
+		super(message);
+		Object.assign(this, options);
+	}
+}
 
 module.exports = function parse(src) {
 	const match = /^(?:(?:https:\/\/)?([^:/]+\.[^:/]+)\/|git@([^:/]+)[:/]|([^/]+):)?([^/\s]+)\/([^/\s#]+)(?:((?:\/[^/\s#]+)+))?\/?(?:#(.+))?/.exec(

--- a/parse-repo.js
+++ b/parse-repo.js
@@ -2,7 +2,7 @@
 const supported = new Set(['github', 'gitlab', 'bitbucket', 'git.sr.ht']);
 
 module.exports = function parse(src) {
-	const match = /^(?:(?:https:\/\/)?([^:/]+\.[^:/]+)\/|git@([^:/]+)[:/]|([^/]+):)?([^/\s]+)\/([^/\s#]+)(?:((?:\/[^/\s#]+)+))?(?:\/)?(?:#(.+))?/.exec(
+	const match = /^(?:(?:https:\/\/)?([^:/]+\.[^:/]+)\/|git@([^:/]+)[:/]|([^/]+):)?([^/\s]+)\/([^/\s#]+)(?:((?:\/[^/\s#]+)+))?\/?(?:#(.+))?/.exec(
 		src
 	);
 	if (!match) {
@@ -17,7 +17,7 @@ module.exports = function parse(src) {
 	);
 	if (!supported.has(site)) {
 		throw new DegitError(
-			`degit supports GitHub, GitLab, Sourcehut and BitBucket`,
+			'degit supports GitHub, GitLab, Sourcehut and BitBucket',
 			{
 				code: 'UNSUPPORTED_HOST'
 			}
@@ -30,12 +30,12 @@ module.exports = function parse(src) {
 	const ref = match[7] || 'HEAD';
 
 	const domain = `${site}.${
-		site === 'bitbucket' ? 'org' : site === 'git.sr.ht' ? '' : 'com'
+		site === 'bitbucket' ? 'org' : (site === 'git.sr.ht' ? '' : 'com')
 	}`;
 	const url = `https://${domain}/${user}/${name}`;
 	const ssh = `git@${domain}:${user}/${name}`;
 
 	const mode = supported.has(site) ? 'tar' : 'git';
 
-	return { site, user, name, ref, url, ssh, subdir, mode };
-}
+	return {site, user, name, ref, url, ssh, subdir, mode};
+};


### PR DESCRIPTION
Prepare for https://github.com/fregante/ghat/issues/9

```diff
- # DO NOT EDIT BLOW, USE: npx ghat fregante/ghatemplates/node --exclude jobs.Test
+ # FILE GENERATED WITH: npx ghat
+ # SOURCE: https://github.com/fregante/ghatemplates
+ # OPTIONS: {"source":"fregante/ghatemplates/node","exclude":["jobs.Test"]}
```

Advantages:

- The command to run is now just `npx ghat`
- There's a full repo URL (clickable for RGH users)
- No cross-platform issues when creating/parsing argv from a string

Disadvantages:

- A bit longer
- Can no longer be copy-pasted as a whole across repositories 😕 